### PR TITLE
Darkmode support

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,5 +9,5 @@ RewriteRule ^legal/$ oxygen_updater_privacy_policy_latest.pdf
 RewriteRule ^faq$ faq.php
 RewriteRule ^faq/$ faq.php
 
-RewriteRule ^inappfaq$ in_app_faq.php
-RewriteRule ^inappfaq/$ in_app_faq.php [L]
+RewriteRule ^inappfaq(?:/(Light|Dark))?$ in_app_faq.php?theme=$1
+RewriteRule ^inappfaq(?:/(Light|Dark))?/$ in_app_faq.php?theme=$1 [L]

--- a/api/v2.3/.htaccess
+++ b/api/v2.3/.htaccess
@@ -25,8 +25,8 @@ RewriteRule ^news/([-0-9]+)/([-0-9]+)/?$ get_news.php?device_id=$1&update_method
 RewriteRule ^news-item/([-0-9]+)?$ get_news_item.php?news_item_id=$1
 RewriteRule ^news-item/([-0-9]+)/?$ get_news_item.php?news_item_id=$1
 
-RewriteRule ^news-content/([-0-9]+)/(.*)?$ get_news_item_contents.php?news_item_id=$1&language=$2
-RewriteRule ^news-content/([-0-9]+)/(.*)/?$ get_news_item_contents.php?news_item_id=$1&language=$2
+RewriteRule ^news-content/([-0-9]+)/(EN|NL)(?:/(Light|Dark))?$ get_news_item_contents.php?news_item_id=$1&language=$2&theme=$3
+RewriteRule ^news-content/([-0-9]+)/(EN|NL)(?:/(Light|Dark))?/$ get_news_item_contents.php?news_item_id=$1&language=$2&theme=$3
 
 RewriteRule ^news-read$ post_news_read.php
 RewriteRule ^news-read/$ post_news_read.php

--- a/api/v2.3/get_news_item_contents.php
+++ b/api/v2.3/get_news_item_contents.php
@@ -30,6 +30,13 @@ if ($theme === 'Dark') {
                   background-color: black;
                   color: white;
                 }
+                
+                /* If clicked on 'black' text color explicitly in news editor then it will add it to inline style.
+                   Override this as well to prevent unreadable text in dark mode
+                  */
+                [style*=\"color: #000000\"] {
+                  color: white !important;
+                }
               </style>";
 }
 

--- a/api/v2.3/get_news_item_contents.php
+++ b/api/v2.3/get_news_item_contents.php
@@ -7,6 +7,7 @@ $database = connectToDatabase();
 // Obtain all required request parameters.
 $newsItemId = $_GET["news_item_id"];
 $language = $_GET["language"];
+$theme = $_GET["theme"]; // Light, Dark or "" ("" only on app 2.7.6 and older)
 
 // Execute the query
 if (strtolower($language) === 'nl') {
@@ -18,10 +19,30 @@ if (strtolower($language) === 'nl') {
 $query->bindParam(":id", $newsItemId);
 $query->execute();
 
-
 // Return the output as HTML
 header('Content-type: text/html');
-echo ($query->fetch(PDO::FETCH_ASSOC)['content']);
+$style = "";
+$contents = $query->fetch(PDO::FETCH_ASSOC)['content'];
+
+if ($theme === 'Dark') {
+    $style = "<style>
+                body {
+                  background-color: black;
+                  color: white;
+                }
+              </style>";
+}
+
+echo "
+        <html lang=" . $language . ">
+          <head>
+            ". $style . "
+          </head>
+          <body>
+          " . $contents . "
+          </body>
+        </html>
+    ";
 
 // Disconnect from the database
 $database = null;

--- a/api/v2.3/get_news_item_contents.php
+++ b/api/v2.3/get_news_item_contents.php
@@ -27,7 +27,7 @@ $contents = $query->fetch(PDO::FETCH_ASSOC)['content'];
 if ($theme === 'Dark') {
     $style = "<style>
                 body {
-                  background-color: black;
+                  background-color: #121212;
                   color: white;
                 }
                 

--- a/in_app_faq.php
+++ b/in_app_faq.php
@@ -8,6 +8,10 @@
     $lang_ = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2) : 'en';
     require_once getTextFileToInclude($lang_, isset($_GET['lang']) ? $_GET['lang'] : null);
 
+    // Theme: Light, Dark or empty (empty only on app versions 2.7.6 and below)
+    $uri = $_SERVER["REQUEST_URI"];
+    $theme = $_GET["theme"];
+
     // HTML Purifier prevents XSS attacks.
     $purifier = initHtmlPurifier();
 
@@ -66,8 +70,18 @@
           integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
           crossorigin="anonymous">
 
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/faq.css">
+    <?php if(strpos($uri, 'inappfaq/Light/') !== FALSE || strpos($uri, 'inappfaq/Dark/') !== FALSE) { ?>
+        <link rel="stylesheet" href="../../css/style.css">
+        <link rel="stylesheet" href="../../css/faq.css">
+
+    <?php } else if(strpos($uri, 'inappfaq/') !== FALSE) { ?>
+        <link rel="stylesheet" href="../css/style.css">
+        <link rel="stylesheet" href="../css/faq.css">
+
+    <?php } else { ?>
+        <link rel="stylesheet" href="css/style.css">
+        <link rel="stylesheet" href="css/faq.css">
+    <?php } ?>
 
     <!-- Javascript -->
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"
@@ -77,6 +91,20 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
             integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
             crossorigin="anonymous"></script>
+
+    <?php if($theme === 'Dark') {?>
+        <style>
+            body {
+                background-color: black;
+                color: white;
+            }
+
+            .panel-body {
+                background-color: #1E1E1E;
+                border-top-color: #1E1E1E !important;
+            }
+        </style>
+    <?php }?>
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/in_app_faq.php
+++ b/in_app_faq.php
@@ -95,13 +95,29 @@
     <?php if($theme === 'Dark') {?>
         <style>
             body {
-                background-color: black;
+                background-color: #121212;
                 color: white;
             }
 
+            a:link:not(.font-white) {
+                color: #f43b46 !important;
+            }
+
+            a:visited {
+                background-color: #f43b46;
+            }
+
+            .panel {
+                border-color: #f43b46 !important;
+            }
+
             .panel-body {
-                background-color: #1E1E1E;
-                border-top-color: #1E1E1E !important;
+                background-color: #1d1d1d;
+                border-top-color: #1d1d1d !important;
+            }
+
+            .panel-heading {
+                background-color: #f43b46 !important;
             }
         </style>
     <?php }?>


### PR DESCRIPTION
## What's changed
### Added support for dark mode in news section
The news-content api can now be called with /Light or /Dark.
If it is called with /Dark, a page with black background and white
text (unless other color is set using the text editor) is returned

Example URLs once merged:
https://oxygenupdater.com/api/v2.3/news-content/77/EN/Dark
https://oxygenupdater.com/api/v2.3/news-content/77/EN/Light

Older versions of the app can still access the API using:
https://oxygenupdater.com/api/v2.3/news-content/77/EN

### Added support for dark mode to faq page
FAQ page can be made dark by appending /Dark to the URL, just like
the news.

New example urls:
https://oxygenupdater.com/inappfaq/Dark
https://oxygenupdater.com/inappfaq/Light

Older app versions can of course stil use:
https://oxygenupdater.com/inappfaq

![darkmode-faq](https://user-images.githubusercontent.com/10106652/62805756-3a545200-baf1-11e9-8746-b2ca99305dbf.JPG)

